### PR TITLE
Highlight matching line and column

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+require('colors');
+
 /**
  * To run, `node smap <path/to/js/file>:<line>:<col> [path to source directory, default is ../../]`
  **/
@@ -104,9 +106,22 @@ fs.readFile(file + ".map", 'utf8', function (err, data) {
 					var code = lines.slice(minLine, maxLine);
 					console.log("Code Section: ");
 					var padLength = Math.max(("" + minLine).length, ("" + maxLine).length) + 1;
+
+
+					function formatLineNumber(currentLine) {
+						if (currentLine == line) {
+							return (pad(currentLine, padLength - 1) + ">| ").bold.red;
+						} else {
+							return pad(currentLine, padLength) + "| ";
+						}
+					}
+
 					var currentLine = minLine;
 					for(var i = 0 ; i < code.length ; i++) {
-						console.log(pad(++currentLine, padLength) + "| " + code[i]);
+						console.log(formatLineNumber(++currentLine) + code[i]);
+						if (currentLine == line && originalPosition.column) {
+							console.log(pad('', padLength + 2 + originalPosition.column) + '^'.bold.red);
+						}
 					}
 				}
 

--- a/index.js
+++ b/index.js
@@ -3,15 +3,8 @@
 /**
  * To run, `node smap <path/to/js/file>:<line>:<col> [path to source directory, default is ../../]`
  **/
-var argv = require('minimist')(process.argv.slice(2), {
-	alias: {
-		"h": "help", 
-		"v":"version",
-		"s": "source-path"
-	}
-});
 
-if(argv["help"]) {
+function showHelp() {
 	console.log("");
 	console.log("Usage: \n\tsourcemap-lookup <path/to/map/file>:<line number>:<column number> [options]");
 
@@ -28,6 +21,24 @@ if(argv["help"]) {
 
 	console.log("");
 	console.log("");
+	return ;
+}
+
+if (process.argv.length <= 2) {
+	showHelp();
+	return ;
+}
+
+var argv = require('minimist')(process.argv.slice(2), {
+	alias: {
+		"h": "help",
+		"v":"version",
+		"s": "source-path"
+	}
+});
+
+if(argv["help"]) {
+	showHelp();
 	return ;
 }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "Ken Koch <kkoch986@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "colors": "^1.1.2",
     "minimist": "^1.2.0",
     "source-map": "^0.5.3"
   }


### PR DESCRIPTION
This PR changes the output so that instead of, e.g.,

```
106 |     var component = this.refs[key];
107 |     if (component.componentDidAppear) {
108 |       component.componentDidAppear();
109 |     }
```

it highlights the matching line and column:

```
106 |     var component = this.refs[key];
107>|     if (component.componentDidAppear) {
                        ^
108 |       component.componentDidAppear();
109 |     }
```

It uses [colors](https://www.npmjs.com/package/colors) for additional emphasis.

I also added handling for no command line arguments.

If you'd like anything to be changed, or if you'd like this to be broken into smaller PRs, please let me know.
